### PR TITLE
Fix event ingestion bug

### DIFF
--- a/services/voting.ts
+++ b/services/voting.ts
@@ -87,7 +87,8 @@ export const VotingReader = {
 
     let offsetAmt = offset + 20 + 16;
     const bufAmt = buf.slice( offsetAmt, offsetAmt + 16);
-    const amt = BigInt("0x0" + bufAmt.toString("hex")).toString(10);
+    const sanitisedBufAmt = "0x" + bufAmt.toString("hex");
+    const amt = BigInt(sanitisedBufAmt.length < 3 ? '0x0' : sanitisedBufAmt).toString(10);
 
     return {
       scriptType,

--- a/services/voting.ts
+++ b/services/voting.ts
@@ -87,7 +87,7 @@ export const VotingReader = {
 
     let offsetAmt = offset + 20 + 16;
     const bufAmt = buf.slice( offsetAmt, offsetAmt + 16);
-    const amt = BigInt("0x" + bufAmt.toString("hex")).toString(10);
+    const amt = BigInt("0x0" + bufAmt.toString("hex")).toString(10);
 
     return {
       scriptType,


### PR DESCRIPTION
Closes #71 

Fixes 
```
$ /app/node_modules/.bin/ts-node cli.ts state update --rps-limit
Processing 17313532 2023-05-22T08:04:23.000Z 3L 1R 1814.51USD read in 0.012s
Event @ 17313532 0x6e986531439c09d22f2953d14b1788d6e26ade4c4ff4af3e5a696f7f9cf8f151 134 SyntaxError: Cannot convert 0x to a BigInt
    at BigInt (<anonymous>)
    at Object.parseScript (/app/services/voting.ts:90:17)
    at /app/services/sync.ts:749:33
    at step (/app/services/sync.ts:44:23)
    at Object.next (/app/services/sync.ts:25:53)
    at fulfilled (/app/services/sync.ts:16:58)
cli.ts state [sub]
```