### PR TITLE
Add indexes to improve performance, decrease cron frequency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
   },
   "resolutions": {
     "webpack": "^5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model MemberEvent {
   gasUsed     BigInt? // gas used for this transaction
   feeUsd      Decimal? @db.Decimal(10, 2) // USD equivalent of the fee
 
+  @@index([address])
   @@map("member_events")
 }
 
@@ -86,6 +87,8 @@ model MemberDelegation {
   updatedAt  DateTime @default(now()) // time of the last delegation update
   userShares Decimal  @db.Decimal(60, 18) // number of delegated shares
 
+  @@index([from])
+  @@index([to])
   @@map("member_delegations")
 }
 
@@ -117,6 +120,7 @@ model Member {
   // delegatesTo MemberDelegation?  @relation("delegatesTo") // relation to delegations OF this member
   // delegates   MemberDelegation[] @relation("delegated") // relation to delegations TO this member
 
+  @@index(userShare)
   @@map("members")
 }
 
@@ -175,6 +179,7 @@ model Voting {
 
   events VotingEvent[] @relation("votingEvents") // relations to events
 
+  @@index([status])
   @@map("voting")
 }
 

--- a/terraform/modules/postgres/local_file_crontab_postgres.tf
+++ b/terraform/modules/postgres/local_file_crontab_postgres.tf
@@ -1,6 +1,6 @@
 resource "local_file" "crontab_postgres" {
   content = <<EOF
-0 1 * * * root cd ${path.cwd} && bash ./bin/postgres-backup.sh >> /var/log/postgres-backups.log 2>&1
+24 4 * * */3 root cd ${path.cwd} && bash ./bin/postgres-backup.sh >> /var/log/postgres-backups.log 2>&1
 EOF
 
   filename = "./cron.d/crontab_postgres"


### PR DESCRIPTION
This PR does two things:
- It adds indexes to some columns
    - I noticed that the EC2 instance's disk was 100% in use permanently and the UI was slow to respond. I used the postgres CLI to watch what queries were taking long to run and added indexes for the affected fields. This has sped things up a great deal, particularly the wallet detail page.
-  The DB backup job was running every hour, which is too often, I've change this to once every 3 days. The rationale for this is that the database contents are a reflection of the blockchain, so can be recreated if needed. Backing up the DB slows the machine down and uses S3 storage space.

These changes have already been applied.