### PR TITLE
Add git pull command to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,5 +50,5 @@ jobs:
         run: |
           echo "::add-mask::$TF_VAR_API3TRACKER_ENDPOINT"
           echo "::add-mask::$TF_VAR_API3TRACKER_ARCHIVE_ENDPOINT"
-          export REMOTE_CMD="cd $SSH_REMOTE_PATH && terraform init && terraform apply -auto-approve && docker system prune -af"
+          export REMOTE_CMD="cd $SSH_REMOTE_PATH && git pull && terraform init && terraform apply -auto-approve && docker system prune -af"
           ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null $SSH_HOST bash -c '"'$REMOTE_CMD'"'


### PR DESCRIPTION
TF is executed via ssh on the EC2 host machine and it is executed inside a clone of this repository (containing the TF state). If that repository is not up to date, TF could deploy old code. This PR adds a git pull which should keep that clone fresh.

Closes #108 