### PR TITLE
Remove display of V1 treasury

### DIFF
--- a/pages/treasury.tsx
+++ b/pages/treasury.tsx
@@ -12,7 +12,8 @@ import { fetchWebconfig } from "../services/webconfig";
 export async function getServerSideProps() {
   const webconfig = fetchWebconfig();
   const results = await Promise.all([
-    Treasuries.fetchList(),
+    // V1 no longer used
+    Treasuries.fetchList().then(list => list.filter(type => type !== 'V1')),
     Blocks.fetchLast(),
   ]);
   const names = results[0];

--- a/services/treasuries.ts
+++ b/services/treasuries.ts
@@ -67,9 +67,15 @@ export const Treasuries = {
           ? null
           : new ethers.Contract(token.address, abiERC20, jsonRpc);
       for (const [contractAddress, contractType] of mapAddresses.entries()) {
-        const tokenBalance = tokenContract
-          ? await tokenContract.balanceOf(contractAddress)
-          : await jsonRpc.getBalance(contractAddress);
+        let tokenBalance;
+        // The V1 treasury no longer holds any tokens
+        if (contractType === TreasuryType.V1) {
+          tokenBalance = 0;
+        } else {
+          tokenBalance = tokenContract
+            ? await tokenContract.balanceOf(contractAddress)
+            : await jsonRpc.getBalance(contractAddress);
+        }
 
         const value = withDecimals(tokenBalance.toString(), token.decimals);
         console.log(contractType, tokenSymbol, value);


### PR DESCRIPTION
Closes #103. Tested locally, with the result being (relative to [the treasuries page](https://tracker.api3.org/treasury)):

![image](https://github.com/user-attachments/assets/a0afc028-4809-42e7-ab2f-43f0d19d34c2)
