### PR TITLE
Upgrade Traefik to v2.11.15

### DIFF
--- a/terraform/modules/traefik/docker_image_traefik.tf
+++ b/terraform/modules/traefik/docker_image_traefik.tf
@@ -1,4 +1,4 @@
 resource "docker_image" traefik {
-    name = "traefik:v2.6.3"
+    name = "traefik:v2.11.15"
     keep_locally = true
 }


### PR DESCRIPTION
This upgrades Traefik to v2.11.15
Traefik v3 requires a full migration with testing and can be deferred for now as v2 is still maintained.

Relates to https://github.com/api3dao/tasks/issues/902#top