### PR TITLE
Disable unused metrics

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -27,7 +27,12 @@ export const Footer = (props: IFooterProps) => {
           ) : null}
           {terms ? (
             <span className="text-center block leading-6 md:inline md:text-left">
-              <a className="xs:py-4 sm:py-0 xs:text-xl sm:text-sm" target="_blank" rel="noreferrer noopener" href={terms}>
+              <a
+                className="xs:py-4 sm:py-0 xs:text-xl sm:text-sm"
+                target="_blank"
+                rel="noreferrer noopener"
+                href={terms}
+              >
                 Terms
               </a>
             </span>
@@ -37,7 +42,12 @@ export const Footer = (props: IFooterProps) => {
           ) : null}
           {github ? (
             <span className="text-center block leading-6 md:inline md:text-left">
-              <a className="xs:py-4 sm:py-0 xs:text-xl sm:text-sm" target="_blank" rel="noreferrer noopener" href={github}>
+              <a
+                className="xs:py-4 sm:py-0 xs:text-xl sm:text-sm"
+                target="_blank"
+                rel="noreferrer noopener"
+                href={github}
+              >
                 Github Source
               </a>
             </span>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import Image from "next/image";
 import Link from "next/link";
 import React from "react";
 
@@ -61,7 +61,10 @@ export const Header = (props: IHeader) => {
       <header className="fixed bg-color-body w-full z-10 top-0 left-0 lg:pb-1 border-b border-1px border-solid">
         <div className="hidden lg:flex items-center mx-auto max-w-screen-lg">
           <div className="flex flex-col py-2">
-            <Link href='/' className="text-color-menu-active text-5xl py-2 text-center font-bold">
+            <Link
+              href="/"
+              className="text-color-menu-active text-5xl py-2 text-center font-bold"
+            >
               API3 DAO Tracker
             </Link>
             <span className="text-color-accent text-sm text-left">
@@ -74,10 +77,19 @@ export const Header = (props: IHeader) => {
         <div className="lg:hidden flex p-3">
           <div className="flex-1">
             <Link href="/" onClick={hide} className="block w-8 h-8">
-              <Image src="/API3x32-white-iso.png" width={32} height={32} alt="API3 DAO Tracker" />
+              <Image
+                src="/API3x32-white-iso.png"
+                width={32}
+                height={32}
+                alt="API3 DAO Tracker"
+              />
             </Link>
           </div>
-          <button name="toggle-mobile-menu" aria-label="Toggle Mobile Menu" onClick={toggle}>
+          <button
+            name="toggle-mobile-menu"
+            aria-label="Toggle Mobile Menu"
+            onClick={toggle}
+          >
             {state.mobileOpen ? iconClose : iconMenu}
           </button>
         </div>

--- a/components/MemberClassification.tsx
+++ b/components/MemberClassification.tsx
@@ -68,7 +68,7 @@ export const MemberClassification = (props: IBadgerProps) => {
               <span className={classBadge + b.className}>{b.name}</span> -{" "}
               <span className="text-xs">{b.title}</span>
             </li>
-          ) : null
+          ) : null,
         )}
       </ul>
     </div>
@@ -81,8 +81,14 @@ export const MemberBadges = (props: IBadgerProps) => {
     <div className="leading-2 text-xs">
       {badges.map((b: any) =>
         props.badges.includes(b.name) ? (
-          <span title={b.title} key={b.name} className={classBadge + b.className}>{b.name}</span>
-        ) : null
+          <span
+            title={b.title}
+            key={b.name}
+            className={classBadge + b.className}
+          >
+            {b.name}
+          </span>
+        ) : null,
       )}
     </div>
   );

--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -9,11 +9,11 @@ export interface IMetaProps {
   values?: Map<string, string>;
 }
 
-const withValues = (txt: string, values: Map<string, string>|undefined) => {
+const withValues = (txt: string, values: Map<string, string> | undefined) => {
   if (!values) return txt;
   let out = txt;
   for (const [_, [k, v]] of values.entries()) {
-    out = out.replaceAll('['+ k + ']', v);
+    out = out.replaceAll("[" + k + "]", v);
   }
   return out;
 };
@@ -26,15 +26,15 @@ export const Meta = (props: IMetaProps) => {
   const title = withValues(pg.title || opengraph.title, props.values);
   const description = withValues(
     pg.description || opengraph.description,
-    props.values
+    props.values,
   );
   const ogTitle = withValues(
     pg.ogTitle || opengraph.ogTitle || title,
-    props.values
+    props.values,
   );
   const ogDescription = withValues(
     pg.ogDescription || opengraph.ogDescription || description,
-    props.values
+    props.values,
   );
 
   const siteName = pg.siteName || opengraph.siteName;

--- a/components/Overview.tsx
+++ b/components/Overview.tsx
@@ -26,31 +26,36 @@ export const Epoch = (props: IEpoch) => {
             {props.isCurrent ? props.epoch + 1 : props.epoch}
           </div>
           <div className="text-3xl uppercase m-0">
-            APR: <strong className="font-bold">{toPct(props.isCurrent ? props.newApr : props.apr)}</strong>
+            APR:{" "}
+            <strong className="font-bold">
+              {toPct(props.isCurrent ? props.newApr : props.apr)}
+            </strong>
           </div>
           <div className="mb-3">
             <span className={darkenTitle}>Epoch Rewards: </span>
-            <strong className="accent">{toPct(props.isCurrent ? props.newRewardsPct : props.rewardsPct)}</strong>
+            <strong className="accent">
+              {toPct(props.isCurrent ? props.newRewardsPct : props.rewardsPct)}
+            </strong>
           </div>
-            {props.isCurrent ? (
-<div className="mb-10">&nbsp;</div>
-            ) : (
-          <div className="my-0">
+          {props.isCurrent ? (
+            <div className="mb-10">&nbsp;</div>
+          ) : (
+            <div className="my-0">
               <span className={darkenTitle}>Staked at the end of epoch: </span>
               <strong>{noDecimals(toCurrency(props.totalStake))}</strong>
-</div>
-            )}
+            </div>
+          )}
           <div className="pt-8">
-            {props.isCurrent ? (
-null
-            ) : (
+            {props.isCurrent ? null : (
               <div className={classTitle}>
                 <strong> {noDecimals(toCurrency(props.mintedShares))}</strong>
                 <span className={darkenTitle}> API3 tokens minted </span>
               </div>
             )}
             <div className="mb-4">
-              <div className={darkenTitle}>{niceDateTime(epochDt.toISOString())}</div>
+              <div className={darkenTitle}>
+                {niceDateTime(epochDt.toISOString())}
+              </div>
             </div>
           </div>
         </div>

--- a/components/Rewards.tsx
+++ b/components/Rewards.tsx
@@ -7,7 +7,6 @@ import { StakingTrend } from "../components/StakingTrend";
 import { noDecimals, niceDate, toCurrency, toPct } from "./../services/format";
 import { type IEpoch, type ISupply } from "./../services/types";
 
-
 export interface IRewardsSummaryProps {
   supply: ISupply;
   latest: IEpoch;
@@ -59,7 +58,9 @@ export const RewardsListSmScreen = (epoch: IEpoch) => (
           {toCurrency(epoch.blockNumber)}
         </a>
       </div>
-      <div className="mb-3 text-center text-xs darken">{niceDate(epoch.createdAt)}</div>
+      <div className="mb-3 text-center text-xs darken">
+        {niceDate(epoch.createdAt)}
+      </div>
       <div className="mb-2 text-center darken">
         APR:{" "}
         <span className="text-bold text-2xl text-color-panel-title">
@@ -92,9 +93,7 @@ export const RewardsListSmScreen = (epoch: IEpoch) => (
       </div>
       <div className="text-center text-xs darken my-5">
         Release Date:{" "}
-        <span className="text-bold darken">
-          {niceDate(epoch.releaseDate)}
-        </span>
+        <span className="text-bold darken">{niceDate(epoch.releaseDate)}</span>
       </div>
     </BorderedPanel>
   </div>

--- a/components/StakingTrend.tsx
+++ b/components/StakingTrend.tsx
@@ -22,14 +22,18 @@ export const StakingTrend = (props: IStakingTrendProps) => {
   }
 
   let note = "";
-  note = stakedLessThanTarget ? "DAO staking target is not reached" : "DAO staking target is reached";
+  note = stakedLessThanTarget
+    ? "DAO staking target is not reached"
+    : "DAO staking target is reached";
   if (isMin) {
     note += ", and APR is at its minimum of 2.5%";
   } else if (isMax) {
     note += ", and APR is at its maximum of 75%";
   } else {
     note += ", so APR will ";
-    note += stakedLessThanTarget ? "increase by 1% for the next epochs until the target is met or APR reaches 75%" : "decrease by 1% for the next epochs until APR reaches 2.5%";
+    note += stakedLessThanTarget
+      ? "increase by 1% for the next epochs until the target is met or APR reaches 75%"
+      : "decrease by 1% for the next epochs until APR reaches 2.5%";
   }
 
   const debugMsg = `apr=${props.apr} staked=${props.totalStaked} target=${props.stakingTarget}`;

--- a/components/VotingEvents.tsx
+++ b/components/VotingEvents.tsx
@@ -50,7 +50,7 @@ const EventDetails = (props: IEventDetails) => {
   if (props.eventName === "CastVote") {
     const supports = props.data[2];
     const votes = noDecimals(
-      withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18)
+      withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18),
     );
     return (
       <div className="text-xs darken mt-1 leading-4">
@@ -87,15 +87,15 @@ const votePower = (row: IVotingEvent) => {
     supports = supported ? "Supports" : "Against";
     votes = noDecimals(
       toCurrency(
-        withDecimals(ethers.BigNumber.from(row.data[3]).toString(), 18)
-      )
+        withDecimals(ethers.BigNumber.from(row.data[3]).toString(), 18),
+      ),
     );
     if (row.totalStake) {
       const total = Number.parseInt(noDecimals(row.totalStake.toString()));
       const abs = Number.parseFloat(
         noDecimals(
-          withDecimals(ethers.BigNumber.from(row.data[3]).toString(), 18)
-        )
+          withDecimals(ethers.BigNumber.from(row.data[3]).toString(), 18),
+        ),
       );
       const pct = ((abs * 100) / total).toFixed(2) + "%";
       return [supports, votes, pct];
@@ -214,7 +214,7 @@ export const VotingEventsList = (props: IVotingEventsListProps) => {
         <ol className="border-t border-color-grey">
           {props.list.map((row, index) => {
             const member = props.members.find(
-              (x: any) => toHex(row.address) === toHex(x.address)
+              (x: any) => toHex(row.address) === toHex(x.address),
             );
             return (
               <VotingEventsListRow
@@ -235,7 +235,7 @@ export const VotingEventsList = (props: IVotingEventsListProps) => {
           <tbody>
             {props.list.map((row, index) => {
               const member = props.members.find(
-                (x: any) => toHex(row.address) === toHex(x.address)
+                (x: any) => toHex(row.address) === toHex(x.address),
               );
               return (
                 <VotingEventsListTr

--- a/components/VotingsList.tsx
+++ b/components/VotingsList.tsx
@@ -187,7 +187,7 @@ export const VotingsListRow = (props: IVotingItem) => {
               Against:{" "}
               {item.totalStaked.toNumber() > 0
                 ? toPct(
-                    item.totalAgainst.mul(100).div(item.totalStaked).toFixed(2)
+                    item.totalAgainst.mul(100).div(item.totalStaked).toFixed(2),
                   )
                 : null}
             </div>

--- a/components/WalletDelegation.tsx
+++ b/components/WalletDelegation.tsx
@@ -26,7 +26,7 @@ export const WalletDelegationThead = () => (
 
 export const WalletDelegationTr = (props: any) => {
   const { index } = props;
-  const {row} = props;
+  const { row } = props;
   return (
     <tr>
       <td className="text-center">{(index || 0) + 1}.</td>
@@ -44,7 +44,7 @@ export const WalletDelegationTr = (props: any) => {
 
 export const WalletDelegationRow = (props: any) => {
   const { index } = props;
-  const {row} = props;
+  const { row } = props;
   return (
     <li className="border-b border-color-grey py-2">
       <div className="flex mr-5 ml-5">
@@ -81,8 +81,7 @@ export const WalletDelegation = (props: IWalletDelegationProps) => {
       {to.length > 0 ? (
         <div className="text-color-panel-title">
           <h2 className="text-sm lg:text-xl font-bold text-center">
-            This member is delegated to{" "}
-            {" by "}
+            This member is delegated to {" by "}
             {toNZ.length} members
           </h2>
           <div className="block sm:hidden">

--- a/components/WalletEvents.tsx
+++ b/components/WalletEvents.tsx
@@ -107,8 +107,9 @@ const SharesOfUser = (props: ISharesOfUserProps) => {
     vesting === "0" &&
     unstakeAmount === "0" &&
     unstakeShares === "0"
-  )
-    {return null;}
+  ) {
+    return null;
+  }
   const unstakeScheduledFor = Number.parseInt(props.user[4]);
   // lastDelegationUpdateTimestamp   uint256 :  0
   // lastProposalTimestamp   uint256 :  1669559759
@@ -146,9 +147,7 @@ const SharesOfUser = (props: ISharesOfUserProps) => {
         <span>
           Unstake Scheduled For:{" "}
           <span className="text-color-panel-title">
-            {new Date(1000 * unstakeScheduledFor)
-              .toISOString()
-              .slice(0, 10)}
+            {new Date(1000 * unstakeScheduledFor).toISOString().slice(0, 10)}
           </span>{" "}
         </span>
       ) : null}
@@ -209,11 +208,15 @@ const EventDetails = (props: IEventDetails) => {
       // source, recipient, amount, release start, release end
       const source: string = props.data[0];
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
-      const tmStart = Number.parseInt(ethers.BigNumber.from(props.data[3]).toString());
+      const tmStart = Number.parseInt(
+        ethers.BigNumber.from(props.data[3]).toString(),
+      );
       const dtStart = new Date(tmStart * 1000);
-      const tmEnd = Number.parseInt(ethers.BigNumber.from(props.data[4]).toString());
+      const tmEnd = Number.parseInt(
+        ethers.BigNumber.from(props.data[4]).toString(),
+      );
       const dtEnd = new Date(tmEnd * 1000);
       return (
         <div className="text-xs darken leading-4">
@@ -238,10 +241,10 @@ const EventDetails = (props: IEventDetails) => {
       const from: string = props.data[0];
       const to: string = props.data[1];
       const shares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
       const total = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -255,10 +258,12 @@ const EventDetails = (props: IEventDetails) => {
               from.replace("0x", "").toLowerCase() === thisWallet ? to : from
             }
           />{" "}
-          <span className="text-color-panel-title">{toCurrency(shares)}</span>{". "}
+          <span className="text-color-panel-title">{toCurrency(shares)}</span>
+          {". "}
           <span className={props.wide ? "ml-1" : "block"}>
             Total:{" "}
-            <span className="text-color-panel-title">{toCurrency(total)}</span>{". "}
+            <span className="text-color-panel-title">{toCurrency(total)}</span>
+            {". "}
           </span>
         </div>
       );
@@ -268,25 +273,24 @@ const EventDetails = (props: IEventDetails) => {
       const to: string = props.data[1];
       const increasedDelegation: boolean = props.data[2];
       const shares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18),
       );
       const total = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[4]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[4]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
           <span className="text-color-panel-title">{toCurrency(shares)}</span>{" "}
           {increasedDelegation ? "more" : "fewer"}{" "}
-          {from.replace("0x", "").toLowerCase() === thisWallet
-            ? "to"
-            : "from"}{" "}
+          {from.replace("0x", "").toLowerCase() === thisWallet ? "to" : "from"}{" "}
           <InternalAddress
             className="text-xs"
             inline={true}
             address={
               from.replace("0x", "").toLowerCase() === thisWallet ? to : from
             }
-          />{". "}
+          />
+          {". "}
           <span className={props.wide ? "ml-1" : "block"}>
             Total:{" "}
             <span className="text-color-panel-title">{toCurrency(total)}</span>{" "}
@@ -299,7 +303,7 @@ const EventDetails = (props: IEventDetails) => {
       const from: string = props.data[0];
       const to: string = props.data[1];
       const shares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -317,22 +321,22 @@ const EventDetails = (props: IEventDetails) => {
     case "Staked": {
       // user, amount, minted_shares, user_unstaked, user_shares, total_shares, total_stake
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       const mintedShares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
       const userUnstaked = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18),
       );
       const userShares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[4]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[4]).toString(), 18),
       );
       const totalShares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[5]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[5]).toString(), 18),
       );
       const totalStake = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[6]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[6]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -340,7 +344,8 @@ const EventDetails = (props: IEventDetails) => {
           tokens. Minted{" "}
           <span className="text-color-panel-title">
             {toCurrency(mintedShares)}
-          </span>{". "}
+          </span>
+          {". "}
           Unstaked{" "}
           <span className="text-color-panel-title">
             {toCurrency(userUnstaked)}
@@ -350,7 +355,8 @@ const EventDetails = (props: IEventDetails) => {
             User has{" "}
             <span className="text-color-panel-title">
               {toCurrency(userShares)}
-            </span>{". "}
+            </span>
+            {". "}
             Total:{" "}
             <span className="text-color-panel-title">
               {toCurrency(totalStake)}
@@ -358,7 +364,8 @@ const EventDetails = (props: IEventDetails) => {
             stake,{" "}
             <span className="text-color-panel-title">
               {toCurrency(totalShares)}
-            </span>{". "}
+            </span>
+            {". "}
           </span>
         </div>
       );
@@ -366,10 +373,10 @@ const EventDetails = (props: IEventDetails) => {
     case "Unstaked": {
       // user, amount, user_unstaked, total_shares, total_stake
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       const userUnstaked = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -385,12 +392,14 @@ const EventDetails = (props: IEventDetails) => {
     case "ScheduledUnstake": {
       // user, amount, shares, scheduled_for, user_shares
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       const shares = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
-      const tm = Number.parseInt(ethers.BigNumber.from(props.data[3]).toString());
+      const tm = Number.parseInt(
+        ethers.BigNumber.from(props.data[3]).toString(),
+      );
       const dt = new Date(tm * 1000);
       return (
         <div className="text-xs darken leading-4">
@@ -408,17 +417,21 @@ const EventDetails = (props: IEventDetails) => {
     case "DepositedVesting": {
       // user, amount, start, end, userUnstaked, userVesting
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
-      const tmStart = Number.parseInt(ethers.BigNumber.from(props.data[2]).toString());
+      const tmStart = Number.parseInt(
+        ethers.BigNumber.from(props.data[2]).toString(),
+      );
       const dtStart = new Date(tmStart * 1000);
-      const tmEnd = Number.parseInt(ethers.BigNumber.from(props.data[3]).toString());
+      const tmEnd = Number.parseInt(
+        ethers.BigNumber.from(props.data[3]).toString(),
+      );
       const dtEnd = new Date(tmEnd * 1000);
       const userUnstaked = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[4]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[4]).toString(), 18),
       );
       const userVesting = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[5]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[5]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -449,10 +462,10 @@ const EventDetails = (props: IEventDetails) => {
     case "VestedTimelock": {
       // user, amount, userVesting
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       const userVesting = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -467,7 +480,7 @@ const EventDetails = (props: IEventDetails) => {
     }
     case "DepositedByTimelockManager": {
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -478,7 +491,7 @@ const EventDetails = (props: IEventDetails) => {
     }
     case "Deposited": {
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       return (
         <div className="text-xs darken leading-4">
@@ -489,11 +502,11 @@ const EventDetails = (props: IEventDetails) => {
     }
     case "Withdrawn": {
       const amount = noDecimals(
-        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18)
+        withDecimals(ethers.BigNumber.from(props.data[1]).toString(), 18),
       );
       if (props.data.length === 3) {
         const userUnstaked = noDecimals(
-          withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18)
+          withDecimals(ethers.BigNumber.from(props.data[2]).toString(), 18),
         );
         return (
           <div className="text-xs darken leading-4">
@@ -519,7 +532,9 @@ const EventDetails = (props: IEventDetails) => {
       }
     }
     case "UpdatedLastProposalTimestamp": {
-      const tm = Number.parseInt(ethers.BigNumber.from(props.data[1]).toString());
+      const tm = Number.parseInt(
+        ethers.BigNumber.from(props.data[1]).toString(),
+      );
       const dt = new Date(tm * 1000);
       return (
         <div className="text-xs darken leading-4">
@@ -587,7 +602,9 @@ const EventDetails = (props: IEventDetails) => {
     if (props.data[0] === undefined) {
       return <div className="darken text-xs">NO DETAILS</div>;
     }
-    const voteId = Number.parseInt(ethers.BigNumber.from(props.data[0]).toString());
+    const voteId = Number.parseInt(
+      ethers.BigNumber.from(props.data[0]).toString(),
+    );
     return (
       <div className="text-xs darken leading-4">
         <VotingLink
@@ -602,10 +619,12 @@ const EventDetails = (props: IEventDetails) => {
     if (props.data[0] === undefined) {
       return <div className="darken text-xs">NO DETAILS</div>;
     }
-    const voteId = Number.parseInt(ethers.BigNumber.from(props.data[0]).toString());
+    const voteId = Number.parseInt(
+      ethers.BigNumber.from(props.data[0]).toString(),
+    );
     const supports = props.data[2];
     const votes = noDecimals(
-      withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18)
+      withDecimals(ethers.BigNumber.from(props.data[3]).toString(), 18),
     );
     return (
       <div className="text-xs darken leading-4">

--- a/components/WalletSummary.tsx
+++ b/components/WalletSummary.tsx
@@ -18,7 +18,7 @@ export const WalletSummary = (props: IWalletSummaryProps) => {
   const classValue = "text-2xl mb-10 text-color-panel-title font-bold";
   const { wallet } = props;
   const userDelegated = new Prisma.Decimal(wallet.userVotingPower).sub(
-    wallet.userShare
+    wallet.userShare,
   );
   const userVotingPower = new Prisma.Decimal(wallet.userVotingPower)
     .mul(100)

--- a/components/WalletsList.tsx
+++ b/components/WalletsList.tsx
@@ -22,12 +22,36 @@ export const WalletsListThead = () => (
   <thead>
     <tr>
       <th className="text-center">#</th>
-      <th className="text-center" title="Date of the first on-chain event related to this member">Joined</th>
-      <th className="text-center" title="Date of the latest on-chain event related to this member">Updated</th>
-      <th className="text-left" title="Member address, ENS name and classification">Wallet</th>
-      <th className="text-right" title="Owned by this member">Owns</th>
-      <th className="text-right" title="% of the voting power">%</th>
-      <th className="text-right" title="Voting power is owned shares plus delegated">Voting Power</th>
+      <th
+        className="text-center"
+        title="Date of the first on-chain event related to this member"
+      >
+        Joined
+      </th>
+      <th
+        className="text-center"
+        title="Date of the latest on-chain event related to this member"
+      >
+        Updated
+      </th>
+      <th
+        className="text-left"
+        title="Member address, ENS name and classification"
+      >
+        Wallet
+      </th>
+      <th className="text-right" title="Owned by this member">
+        Owns
+      </th>
+      <th className="text-right" title="% of the voting power">
+        %
+      </th>
+      <th
+        className="text-right"
+        title="Voting power is owned shares plus delegated"
+      >
+        Voting Power
+      </th>
     </tr>
   </thead>
 );
@@ -39,7 +63,7 @@ interface IWalletsListRow {
 }
 
 export const WalletsListTr = (props: IWalletsListRow) => {
-  const {row} = props;
+  const { row } = props;
   const userVotingPower = new Prisma.Decimal(row.userVotingPower)
     .mul(100)
     .div(props.totalVotingPower);
@@ -55,13 +79,12 @@ export const WalletsListTr = (props: IWalletsListRow) => {
         {niceDateTime(row.updatedAt)}
       </td>
       <td className="text-left">
-        <Link
-          href={`/wallets/${toHex(row.address)}`}
-          className="text-bold"
-        >
+        <Link href={`/wallets/${toHex(row.address)}`} className="text-bold">
           {row.ensName ? (
             <div className="">
-              <div className="text-color-panel-title leading-1 font-bold">{row.ensName}</div>
+              <div className="text-color-panel-title leading-1 font-bold">
+                {row.ensName}
+              </div>
               <div
                 className="leading-1 accent"
                 style={{ fontFamily: "monospace", cursor: "pointer" }}
@@ -96,7 +119,7 @@ export const WalletsListTr = (props: IWalletsListRow) => {
 };
 
 export const WalletsListRow = (props: IWalletsListRow) => {
-  const {row} = props;
+  const { row } = props;
   const userVotingPower = new Prisma.Decimal(row.userVotingPower)
     .mul(100)
     .div(props.totalVotingPower);

--- a/components/WalletsSearch.tsx
+++ b/components/WalletsSearch.tsx
@@ -16,7 +16,7 @@ export const WalletsSearch = (props: IWalletsSearchProps) => {
       () => {
         props.onChange(e.target.value);
       },
-      300
+      300,
     );
   };
   return (

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,3 +1,3 @@
-export {Footer} from "./Footer";
-export {Header} from "./Header";
-export {Meta} from "./Meta";
+export { Footer } from "./Footer";
+export { Header } from "./Header";
+export { Meta } from "./Meta";

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:upload": "cat pgapi3dao.sql.gz | gzip -d - | docker exec -i $(docker ps -q --filter label=role=postgres --filter label=project=api3tracker)  sh -c 'psql -U $POSTGRES_USER -d $POSTGRES_DB -h 127.0.0.1'",
     "cache:dump": "(docker exec -i pgapi3dao pg_dump --no-owner --format plain --clean --if-exists --table sync_status --table cache_votings --table cache_blocks --table cache_ens --table cache_user_shares --table cache_total_shares --table cache_logs --table cache_receipts --table cache_tx -U postgres -h 127.0.0.1 api3dao > cache.sql) && (echo '\nUPDATE public.sync_status SET processed = 0;\n ' >> cache.sql) && find . -name cache.sql.gz -delete && gzip cache.sql",
     "cache:restore": "cat cache.sql.gz | gzip -d - | docker exec -i pgapi3dao psql -U postgres -h 127.0.0.1 -d api3dao",
+    "lint:fix": "yarn format",
     "format": "prettier --write \"./**/*.{ts,tsx,js,jsx,css,scss,md,json,prisma}\" --loglevel silent",
     "format:check": "prettier --check \"./**/*.{ts,tsx,js,jsx,css,scss,md,json,prisma}\" --loglevel debug",
     "state:reset": "TS_NODE_PROJECT=./tsconfig.cli.json yarn ts-node -T cli.ts state reset",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -10,14 +10,9 @@ const FourOhFour: NextPage = () => {
     <div>
       <Header active="/" />
       <h1>404 - Page Not Found</h1>
-      <Footer
-        showGas={gas}
-        changeGas={setGas}
-        github={''}
-        blockNumber={0}
-      />
+      <Footer showGas={gas} changeGas={setGas} github={""} blockNumber={0} />
     </div>
   );
-}
+};
 
 export default FourOhFour;

--- a/pages/api/json/votings/[id].tsx
+++ b/pages/api/json/votings/[id].tsx
@@ -1,4 +1,4 @@
-import {uniq} from "lodash";
+import { uniq } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { stringify } from "superjson";
 
@@ -12,9 +12,9 @@ const uniqueArray = (arr: Array<any>): Array<any> => {
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<string>
+  res: NextApiResponse<string>,
 ) {
-  const id = req.query.id as string || "";
+  const id = (req.query.id as string) || "";
   const results = await Promise.all([
     Votings.fetch(id),
     VotingEvents.fetchList(id),
@@ -24,11 +24,10 @@ export default async function handler(
   const addresses = uniqueArray(events.map((x: any) => x.address));
   const members = await Wallets.fetchByAddresses(addresses);
   const out = {
-      id,
-      voting: serializable(voting),
-      events: serializable(events),
-      members: serializable(members),
+    id,
+    voting: serializable(voting),
+    events: serializable(events),
+    members: serializable(members),
   };
   res.status(200).json(JSON.parse(stringify(out)).json);
 }
-

--- a/pages/api/metrics.ts
+++ b/pages/api/metrics.ts
@@ -46,6 +46,7 @@ export default async function handler(
     out.push("processed_block_number " + status[0].processed);
   }
 
+  // Multiple queries below are commented as they slow down the response of this endpoint, and we don't every use the outputs.
   // 2. treasuries balances
   // const names = await Treasuries.fetchList();
   // if (names.length > 0) out.push("");

--- a/pages/api/metrics.ts
+++ b/pages/api/metrics.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { Votings, Wallets, Supply, Treasuries } from "../../services/api";
+// import { Votings, Wallets, Supply, Treasuries } from "../../services/api";
 
 import prisma from "./../../services/db";
 
@@ -47,152 +47,152 @@ export default async function handler(
   }
 
   // 2. treasuries balances
-  const names = await Treasuries.fetchList();
-  if (names.length > 0) out.push("");
-  for (const ttype of names) {
-    const tokens = await Treasuries.fetch(ttype);
-    const valueAPI3 =
-      tokens
-        .filter((x: any) => x.token === "API3")
-        .map((x: any) => x.value)[0] || 0;
-    const valueUSDC =
-      tokens
-        .filter((x: any) => x.token === "USDC")
-        .map((x: any) => x.value)[0] || 0;
-    const valueETH =
-      tokens
-        .filter((x: any) => x.token === "ETH")
-        .map((x: any) => x.value)[0] || 0;
-    out.push("# HELP treasury_api3: API3 tokens in the treasury");
-    out.push("# TYPE treasury_api3: gauge");
-    out.push('treasury_api3{name="' + ttype + '"} ' + valueAPI3);
-    out.push("# HELP treasury_usdc: USDC tokens in the treasury");
-    out.push("# TYPE treasury_usdc: gauge");
-    out.push('treasury_usdc{name="' + ttype + '"} ' + valueUSDC);
-    out.push("# HELP treasury_eth: ETH balance in the treasury");
-    out.push("# TYPE treasury_eth: gauge");
-    out.push('treasury_eth{name="' + ttype + '"} ' + valueETH);
-  }
+  // const names = await Treasuries.fetchList();
+  // if (names.length > 0) out.push("");
+  // for (const ttype of names) {
+  //   const tokens = await Treasuries.fetch(ttype);
+  //   const valueAPI3 =
+  //     tokens
+  //       .filter((x: any) => x.token === "API3")
+  //       .map((x: any) => x.value)[0] || 0;
+  //   const valueUSDC =
+  //     tokens
+  //       .filter((x: any) => x.token === "USDC")
+  //       .map((x: any) => x.value)[0] || 0;
+  //   const valueETH =
+  //     tokens
+  //       .filter((x: any) => x.token === "ETH")
+  //       .map((x: any) => x.value)[0] || 0;
+  //   out.push("# HELP treasury_api3: API3 tokens in the treasury");
+  //   out.push("# TYPE treasury_api3: gauge");
+  //   out.push('treasury_api3{name="' + ttype + '"} ' + valueAPI3);
+  //   out.push("# HELP treasury_usdc: USDC tokens in the treasury");
+  //   out.push("# TYPE treasury_usdc: gauge");
+  //   out.push('treasury_usdc{name="' + ttype + '"} ' + valueUSDC);
+  //   out.push("# HELP treasury_eth: ETH balance in the treasury");
+  //   out.push("# TYPE treasury_eth: gauge");
+  //   out.push('treasury_eth{name="' + ttype + '"} ' + valueETH);
+  // }
 
   // 3. supply
-  const supply = await Supply.fetch();
-  if (supply) {
-    out.push("# HELP circulating_supply Circulating Supply");
-    out.push("# TYPE circulating_supply gauge");
-    out.push("circulating_supply " + supply.circulatingSupply.toString());
-
-    out.push("# HELP total_staked Total Staked Tokens");
-    out.push("# TYPE total_staked gauge");
-    out.push("total_staked " + supply.totalStaked.toString());
-
-    out.push("# HELP staking_target Staking Target");
-    out.push("# TYPE staking_target gauge");
-    out.push("staking_target " + supply.stakingTarget.toString());
-
-    out.push("# HELP staking_target_pct Reaching staking target, in percents");
-    out.push("# TYPE staking_target_pct gauge");
-    out.push(
-      "staking_target_pct " +
-        supply.totalStaked.mul(100).div(supply.stakingTarget).toString(),
-    );
-
-    // out.push("total_locked " + supply.totalLocked.toString());
-    out.push("# HELP locked number of locked tokens");
-    out.push("# TYPE locked gauge");
-    out.push(
-      'locked{where="governance"} ' + supply.lockedByGovernance.toString(),
-    );
-    out.push('locked{where="vestings"} ' + supply.lockedVestings.toString());
-    out.push('locked{where="rewards"} ' + supply.lockedRewards.toString());
-    out.push('locked{where="time"} ' + supply.timeLocked.toString());
-  }
+  // const supply = await Supply.fetch();
+  // if (supply) {
+  //   out.push("# HELP circulating_supply Circulating Supply");
+  //   out.push("# TYPE circulating_supply gauge");
+  //   out.push("circulating_supply " + supply.circulatingSupply.toString());
+  //
+  //   out.push("# HELP total_staked Total Staked Tokens");
+  //   out.push("# TYPE total_staked gauge");
+  //   out.push("total_staked " + supply.totalStaked.toString());
+  //
+  //   out.push("# HELP staking_target Staking Target");
+  //   out.push("# TYPE staking_target gauge");
+  //   out.push("staking_target " + supply.stakingTarget.toString());
+  //
+  //   out.push("# HELP staking_target_pct Reaching staking target, in percents");
+  //   out.push("# TYPE staking_target_pct gauge");
+  //   out.push(
+  //     "staking_target_pct " +
+  //       supply.totalStaked.mul(100).div(supply.stakingTarget).toString(),
+  //   );
+  //
+  //   // out.push("total_locked " + supply.totalLocked.toString());
+  //   out.push("# HELP locked number of locked tokens");
+  //   out.push("# TYPE locked gauge");
+  //   out.push(
+  //     'locked{where="governance"} ' + supply.lockedByGovernance.toString(),
+  //   );
+  //   out.push('locked{where="vestings"} ' + supply.lockedVestings.toString());
+  //   out.push('locked{where="rewards"} ' + supply.lockedRewards.toString());
+  //   out.push('locked{where="time"} ' + supply.timeLocked.toString());
+  // }
 
   // 4. Number of members (per tag)
-  out.push("");
-  const total = await Wallets.fetchCount("");
-  out.push("# TYPE members_total gauge");
-  out.push("members_total " + total);
-  const vested = await Wallets.fetchCount("vested");
-  out.push("# TYPE members_total_vested gauge");
-  out.push("members_total_vested " + vested);
-  const voters = await Wallets.fetchCount("voter");
-  out.push("# TYPE members_total_voters gauge");
-  out.push("members_total_voters " + voters);
-  const supports = await Wallets.fetchCount("supports");
-  out.push("# TYPE members_total_supports gauge");
-  out.push("members_total_supports " + supports);
-  const withdrawn = await Wallets.fetchCount("withdrawn");
-  out.push("# TYPE members_total_withdrawn gauge");
-  out.push("members_total_withdrawn " + withdrawn);
+  // out.push("");
+  // const total = await Wallets.fetchCount("");
+  // out.push("# TYPE members_total gauge");
+  // out.push("members_total " + total);
+  // const vested = await Wallets.fetchCount("vested");
+  // out.push("# TYPE members_total_vested gauge");
+  // out.push("members_total_vested " + vested);
+  // const voters = await Wallets.fetchCount("voter");
+  // out.push("# TYPE members_total_voters gauge");
+  // out.push("members_total_voters " + voters);
+  // const supports = await Wallets.fetchCount("supports");
+  // out.push("# TYPE members_total_supports gauge");
+  // out.push("members_total_supports " + supports);
+  // const withdrawn = await Wallets.fetchCount("withdrawn");
+  // out.push("# TYPE members_total_withdrawn gauge");
+  // out.push("members_total_withdrawn " + withdrawn);
 
   // 5. Number of votes (per status)
-  out.push("");
-  out.push("# HELP votings number of votings");
-  out.push("# TYPE votings gauge");
-  const counts = await Votings.fetchCounts();
-  for (const v of counts) {
-    out.push('votings{status="' + v.status + '"} ' + v.total);
-  }
+  // out.push("");
+  // out.push("# HELP votings number of votings");
+  // out.push("# TYPE votings gauge");
+  // const counts = await Votings.fetchCounts();
+  // for (const v of counts) {
+  //   out.push('votings{status="' + v.status + '"} ' + v.total);
+  // }
 
   // 6. Status estimates - of downloaded user state history
-  out.push("");
-  const blocksWithStatus = (
-    await prisma.memberEvent.groupBy({
-      where: { eventName: "Status" },
-      by: ["blockNumber"],
-    })
-  ).reduce((map: any, obj: any) => {
-    map[obj.blockNumber] = 1;
-    return map;
-  }, {});
+  // out.push("");
+  // const blocksWithStatus = (
+  //   await prisma.memberEvent.groupBy({
+  //     where: { eventName: "Status" },
+  //     by: ["blockNumber"],
+  //   })
+  // ).reduce((map: any, obj: any) => {
+  //   map[obj.blockNumber] = 1;
+  //   return map;
+  // }, {});
+  //
+  // const blocksWithoutStatusTotal = (
+  //   await prisma.memberEvent.groupBy({
+  //     where: { eventName: { not: "Status" } },
+  //     by: ["blockNumber"],
+  //   })
+  // )
+  //   .map((x: any) => 1 - (blocksWithStatus[x.blockNumber] || 0))
+  //   .reduce((partialSum, a) => partialSum + a, 0);
+  //
+  // out.push(
+  //   "# HELP blocks_without_shares returns the estimate amount of history to be downloaded",
+  // );
+  // out.push("# TYPE blocks_without_shares gauge");
+  // out.push("blocks_without_status " + blocksWithoutStatusTotal);
+  // out.push(
+  //   "# HELP blocks_with_status returns the estimate amount of history blocks that were already downloaded",
+  // );
+  // out.push("# TYPE blocks_with_status gauge");
+  // out.push("blocks_with_status " + Object.keys(blocksWithStatus).length);
 
-  const blocksWithoutStatusTotal = (
-    await prisma.memberEvent.groupBy({
-      where: { eventName: { not: "Status" } },
-      by: ["blockNumber"],
-    })
-  )
-    .map((x: any) => 1 - (blocksWithStatus[x.blockNumber] || 0))
-    .reduce((partialSum, a) => partialSum + a, 0);
-
-  out.push(
-    "# HELP blocks_without_shares returns the estimate amount of history to be downloaded",
-  );
-  out.push("# TYPE blocks_without_shares gauge");
-  out.push("blocks_without_status " + blocksWithoutStatusTotal);
-  out.push(
-    "# HELP blocks_with_status returns the estimate amount of history blocks that were already downloaded",
-  );
-  out.push("# TYPE blocks_with_status gauge");
-  out.push("blocks_with_status " + Object.keys(blocksWithStatus).length);
-
-  const addressWithStatus = (
-    await prisma.memberEvent.groupBy({
-      where: { eventName: "Status" },
-      by: ["address"],
-    })
-  ).reduce((map: any, obj: any) => {
-    map[obj.address] = 1;
-    return map;
-  }, {});
-  const addressWithRewardsTotal = (
-    await prisma.memberEvent.groupBy({
-      where: { eventName: { not: "Status" } },
-      by: ["address"],
-    })
-  )
-    .map((x: any) => 1 - (addressWithStatus[x.address] || 0))
-    .reduce((partialSum, a) => partialSum + a, 0);
-  out.push(
-    "# HELP address_without_status returns the amount of members that have no any shares history checked",
-  );
-  out.push("# TYPE address_without_status gauge");
-  out.push("address_without_status " + addressWithRewardsTotal);
-  out.push(
-    "# HELP address_with_status returns the estimate amount of addresses that were already downloaded",
-  );
-  out.push("# TYPE address_with_status gauge");
-  out.push("address_with_status " + Object.keys(addressWithStatus).length);
+  // const addressWithStatus = (
+  //   await prisma.memberEvent.groupBy({
+  //     where: { eventName: "Status" },
+  //     by: ["address"],
+  //   })
+  // ).reduce((map: any, obj: any) => {
+  //   map[obj.address] = 1;
+  //   return map;
+  // }, {});
+  // const addressWithRewardsTotal = (
+  //   await prisma.memberEvent.groupBy({
+  //     where: { eventName: { not: "Status" } },
+  //     by: ["address"],
+  //   })
+  // )
+  //   .map((x: any) => 1 - (addressWithStatus[x.address] || 0))
+  //   .reduce((partialSum, a) => partialSum + a, 0);
+  // out.push(
+  //   "# HELP address_without_status returns the amount of members that have no any shares history checked",
+  // );
+  // out.push("# TYPE address_without_status gauge");
+  // out.push("address_without_status " + addressWithRewardsTotal);
+  // out.push(
+  //   "# HELP address_with_status returns the estimate amount of addresses that were already downloaded",
+  // );
+  // out.push("# TYPE address_with_status gauge");
+  // out.push("address_with_status " + Object.keys(addressWithStatus).length);
 
   res.status(200).send(out.join("\n"));
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,11 @@ import { TokenSupply } from "../components/TokenSupply";
 import { Epochs, Supply, Votings, Wallets, Blocks } from "../services/api";
 import { serializable } from "../services/format";
 import { VoteGas } from "../services/gas";
-import { type IBlockNumber, type ISupply, type IEpoch } from "../services/types";
+import {
+  type IBlockNumber,
+  type ISupply,
+  type IEpoch,
+} from "../services/types";
 import { fetchWebconfig } from "../services/webconfig";
 
 export async function getServerSideProps() {
@@ -19,7 +23,7 @@ export async function getServerSideProps() {
     Epochs.fetchLatest(2, true),
     Supply.fetch(),
     Wallets.totalActive(),
-    Votings.totalByStatus('executed'),
+    Votings.totalByStatus("executed"),
     Blocks.fetchLast(),
   ]);
   const latest: Array<IEpoch> = results[0];
@@ -28,7 +32,7 @@ export async function getServerSideProps() {
   const totalExecutedVotings: number = results[3];
   const lastBlock: IBlockNumber = results[4];
   const current: IEpoch = latest[0];
-  const values = new Map<string,string>(); // values
+  const values = new Map<string, string>(); // values
   return {
     props: {
       webconfig: fetchWebconfig(),
@@ -71,10 +75,12 @@ const HomePage: NextPage = (props: any) => {
           ) : (
             <div>
               <p className="mx-4 mb-8 text-center">
-                API3 DAO has {" "}
-                <a href="./wallets">{totalCurrentWallets} current members</a> and {" "}
+                API3 DAO has{" "}
+                <a href="./wallets">{totalCurrentWallets} current members</a>{" "}
+                and{" "}
                 <a href="./votings">
-                  {totalExecutedVotings} completed proposal{totalExecutedVotings === 1 ? "" : "s"}
+                  {totalExecutedVotings} completed proposal
+                  {totalExecutedVotings === 1 ? "" : "s"}
                 </a>
               </p>
               <h2 className="mt-4 mb-0 font-bold text-center text-2xl uppercase">

--- a/pages/rewards.tsx
+++ b/pages/rewards.tsx
@@ -7,7 +7,11 @@ import { RewardsList, RewardsSummary } from "../components/Rewards";
 import { Epochs, Supply, Blocks } from "../services/api";
 import { serializable } from "../services/format";
 import { VoteGas } from "../services/gas";
-import { type IBlockNumber, type IEpoch, type ISupply } from "../services/types";
+import {
+  type IBlockNumber,
+  type IEpoch,
+  type ISupply,
+} from "../services/types";
 import { fetchWebconfig } from "../services/webconfig";
 
 export async function getServerSideProps() {
@@ -46,13 +50,17 @@ const RewardsPage: NextPage = (props: any) => {
       <main>
         <h1 className="uppercase">API3 DAO Rewards</h1>
         {isEmpty ? (
-          <div className="text-color-grey text-center">No epochs data yet. Please import database.</div>
-        ) : <RewardsSummary
-          totalMinted={props.totalMinted}
-          latest={latest[0]}
-          supply={supply}
-        />}
-        {(isEmpty) ? null: <RewardsList list={latest} />}
+          <div className="text-color-grey text-center">
+            No epochs data yet. Please import database.
+          </div>
+        ) : (
+          <RewardsSummary
+            totalMinted={props.totalMinted}
+            latest={latest[0]}
+            supply={supply}
+          />
+        )}
+        {isEmpty ? null : <RewardsList list={latest} />}
         <div className="pb-20">&nbsp;</div>
       </main>
 

--- a/pages/treasury.tsx
+++ b/pages/treasury.tsx
@@ -13,7 +13,7 @@ export async function getServerSideProps() {
   const webconfig = fetchWebconfig();
   const results = await Promise.all([
     // V1 no longer used
-    Treasuries.fetchList().then(list => list.filter(type => type !== 'V1')),
+    Treasuries.fetchList().then((list) => list.filter((type) => type !== "V1")),
     Blocks.fetchLast(),
   ]);
   const names = results[0];
@@ -40,7 +40,7 @@ export async function getServerSideProps() {
         valueUSDC,
         valueETH,
       };
-    })
+    }),
   );
   const values = new Map<string, string>();
   return {

--- a/pages/votings.tsx
+++ b/pages/votings.tsx
@@ -66,7 +66,8 @@ const VotingsPage: NextPage = (props: any) => {
             {pending.length > 0 ? (
               <section className="max-w-screen-lg mx-auto">
                 <div className="text-center text-xl">
-                  {pending.length} Pending Proposal{(pending.length === 1) ? '' : 's'}
+                  {pending.length} Pending Proposal
+                  {pending.length === 1 ? "" : "s"}
                 </div>
                 <VotingsList showGas={gas} list={Votings.fromList(pending)} />
               </section>
@@ -74,8 +75,8 @@ const VotingsPage: NextPage = (props: any) => {
             {executed.length > 0 ? (
               <section className="max-w-screen-lg mx-auto">
                 <div className="text-center text-xl">
-                  {executed.length} Executed Proposal{(executed.length === 1) ? '' : 's'}
-
+                  {executed.length} Executed Proposal
+                  {executed.length === 1 ? "" : "s"}
                 </div>
                 <VotingsList showGas={gas} list={Votings.fromList(executed)} />
               </section>
@@ -83,8 +84,8 @@ const VotingsPage: NextPage = (props: any) => {
             {invalid.length > 0 ? (
               <section className="max-w-screen-lg mx-auto">
                 <div className="text-center text-xl">
-                  {invalid.length} Invalid Proposal{(invalid.length === 1) ? '' : 's'}
-
+                  {invalid.length} Invalid Proposal
+                  {invalid.length === 1 ? "" : "s"}
                 </div>
                 <VotingsList showGas={gas} list={Votings.fromList(invalid)} />
               </section>
@@ -92,8 +93,8 @@ const VotingsPage: NextPage = (props: any) => {
             {rejected.length > 0 ? (
               <section className="max-w-screen-lg mx-auto">
                 <div className="text-center text-xl">
-                  {rejected.length} Rejected Proposal{(rejected.length === 1) ? '' : 's'}
-
+                  {rejected.length} Rejected Proposal
+                  {rejected.length === 1 ? "" : "s"}
                 </div>
                 <VotingsList showGas={gas} list={Votings.fromList(rejected)} />
               </section>

--- a/pages/votings/[id].tsx
+++ b/pages/votings/[id].tsx
@@ -1,4 +1,4 @@
-import {uniq } from "lodash";
+import { uniq } from "lodash";
 import type { NextPage } from "next";
 import { useState } from "react";
 
@@ -8,7 +8,11 @@ import { VotingSummary } from "../../components/VotingSummary";
 import { Wallets, Votings, VotingEvents, Blocks } from "../../services/api";
 import { serializable } from "../../services/format";
 import { VoteGas } from "../../services/gas";
-import { type IBlockNumber, type IVoting, type IVotingEvent } from "../../services/types";
+import {
+  type IBlockNumber,
+  type IVoting,
+  type IVotingEvent,
+} from "../../services/types";
 import { fetchWebconfig } from "../../services/webconfig";
 
 const uniqueArray = (arr: Array<any>): Array<any> => {
@@ -16,7 +20,7 @@ const uniqueArray = (arr: Array<any>): Array<any> => {
 };
 
 export async function getServerSideProps(context: any) {
-  const {id} = context.params;
+  const { id } = context.params;
   const results = await Promise.all([
     Votings.fetch(id),
     VotingEvents.fetchList(id),

--- a/pages/wallets.tsx
+++ b/pages/wallets.tsx
@@ -29,7 +29,7 @@ export async function getServerSideProps(context: any) {
     CacheTotals.fetch(),
     Wallets.totalActive(),
   ]);
-  const {list} = results[0];
+  const { list } = results[0];
   const total = results[3];
   const lastBlock: IBlockNumber = results[1];
   const totalShares: any = results[2];
@@ -115,7 +115,7 @@ const WalletsPage: NextPage = (props: any) => {
           .then(() => setLoading(false))
           .catch((_: any) => setLoading(false));
       },
-      300
+      300,
     );
   };
 
@@ -129,7 +129,7 @@ const WalletsPage: NextPage = (props: any) => {
         "&take=" +
         state.take +
         "&skip=" +
-        state.list.length
+        state.list.length,
     )
       .then(appendData)
       .then(() => setLoadingMore(false))

--- a/pages/wallets/[id].tsx
+++ b/pages/wallets/[id].tsx
@@ -25,7 +25,7 @@ import {
 import { fetchWebconfig } from "../../services/webconfig";
 
 export async function getServerSideProps(context: any) {
-  const {id} = context.params;
+  const { id } = context.params;
   const address = Buffer.from(id.replace(/0x/, ""), "hex");
   const results = await Promise.all([
     Wallets.fetch(address),
@@ -44,15 +44,15 @@ export async function getServerSideProps(context: any) {
   const delegationsFrom: Array<IDelegation> = results[5];
   const delegationsTo: Array<IDelegation> = results[6];
   const values = new Map<string, string>();
-  let memberName = '';
-  let memberPower = '';
+  let memberName = "";
+  let memberPower = "";
   if (wallet) {
-    memberName = '0x' + wallet.address.toString();
-    if (wallet.ensName) memberName = wallet.ensName + ' (' + memberName + ')';
-    memberPower = wallet.userVotingPower.toString() + ' shares';
+    memberName = "0x" + wallet.address.toString();
+    if (wallet.ensName) memberName = wallet.ensName + " (" + memberName + ")";
+    memberPower = wallet.userVotingPower.toString() + " shares";
   }
-  values.set('MEMBER_NAME', memberName);
-  values.set('MEMBER_POWER', memberPower);
+  values.set("MEMBER_NAME", memberName);
+  values.set("MEMBER_POWER", memberPower);
   return {
     props: {
       delegationsFrom: serializable(delegationsFrom),
@@ -70,7 +70,8 @@ export async function getServerSideProps(context: any) {
 }
 
 const WalletDetailsPage: NextPage = (props: any) => {
-  const { lastBlock, wallet, events, totalShares, votings, webconfig, values } = props;
+  const { lastBlock, wallet, events, totalShares, votings, webconfig, values } =
+    props;
   const { delegationsFrom, delegationsTo } = props;
   const total = totalShares;
   const [gas, setGas] = useState<boolean>(VoteGas.appearance);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,8 +35,18 @@ body {
 
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    Fira Sans,
+    Droid Sans,
+    Helvetica Neue,
+    sans-serif;
 }
 
 a {
@@ -290,4 +300,3 @@ a.icon {
 .link-icon {
   fill: var(--color-link);
 }
-

--- a/styles/nprogress-overrides.css
+++ b/styles/nprogress-overrides.css
@@ -3,5 +3,7 @@
 }
 
 #nprogress .peg {
-  box-shadow: 0 0 10px var(--color-accent), 0 0 5px var(--color-accent);
+  box-shadow:
+    0 0 10px var(--color-accent),
+    0 0 5px var(--color-accent);
 }


### PR DESCRIPTION
This PR removes unused metrics from the metrics endpoint. 

Some of the metrics provided by the existing endpoint code run slow queries on the DB, which bog down the server and often time out.

Closes #113 