### PR TITLE
fix: rename wrongly named unstake to unstaking

### DIFF
--- a/components/WalletEvents.tsx
+++ b/components/WalletEvents.tsx
@@ -129,17 +129,9 @@ const SharesOfUser = (props: ISharesOfUserProps) => {
       )}
       {unstakeAmount == "0" ? null : (
         <span>
-          Unstake Amount:{" "}
+          Unstaking:{" "}
           <span className="text-color-panel-title">
             {toCurrency(unstakeAmount)}
-          </span>{" "}
-        </span>
-      )}
-      {unstakeShares == "0" ? null : (
-        <span>
-          Unstaked:{" "}
-          <span className="text-color-panel-title">
-            {toCurrency(unstakeShares)}
           </span>{" "}
         </span>
       )}

--- a/components/WalletSummary.tsx
+++ b/components/WalletSummary.tsx
@@ -91,7 +91,7 @@ export const WalletSummary = (props: IWalletSummaryProps) => {
                 </div>
               </div>
               <div className="flex-1">
-                <div className={classTitle}>Unstake</div>
+                <div className={classTitle}>Unstaking</div>
                 <div className={classValue}>
                   {noDecimals(toCurrency(wallet.userUnstake))}
                 </div>


### PR DESCRIPTION
Closes #115. "Unstake" is actually the number of that the user is actively unstaking. This PR updates the language to address this. This PR also removes reporting of *shares* being unstaked as this isn't meaningful. For clarity, the number of tokens being unstaked is retained.

See #118 for adding a 4th field, "Unstaked".

Updates, in visual form:

![image](https://github.com/user-attachments/assets/79b446dc-1b10-4dbb-bf61-4d324bf77283)
