### PR TITLE
fix: small misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Developers can run some or all services locally using Docker Swarm, or even bare
 One combination is running just postgres locally using Docker, eg:
 
 ```bash
-docker run --rm -ti -p 5432:5432 postgres:15
+docker run --rm -ti -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:15
 ```
 
-and then running the FE and BE services directly (refer to Cron jobs below and `yarn next dev` in `package.json`).
+and then running the FE and BE services directly (refer to Cron jobs below and `yarn dev` in `package.json`).
 
 Alternatively, one can run services using Docker Swarm, but this lacks hot-reloading.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ens:download": "API3TRACKER_ENDPOINT=${API3TRACKER_ENDPOINT:-`chainstate --endpoints -t alchemy,mainnet`} TS_NODE_PROJECT=./tsconfig.cli.json yarn ts-node -T cli.ts ens download",
     "lint:eslint": "eslint --report-unused-disable-directives --ext .ts,.tsx --max-warnings 0 .",
     "lint:next": "next lint",
-    "lint:prettier": "prettier --check \"./**/*.{ts,js,md,json}\"",
+    "lint:prettier": "prettier --check \"./**/*.{ts,tsx,js,md,json}\"",
     "lint:tsc": "tsc --build .",
     "lint": "yarn run lint:eslint && yarn run lint:next && yarn run lint:prettier && yarn run lint:tsc",
     "logs:reset": "TS_NODE_PROJECT=./tsconfig.cli.json yarn ts-node -T cli.ts logs reset",


### PR DESCRIPTION
Simple PR; the update to the docker run command comes after encountering the following with the command as currently written:
```
❯ docker run --rm -ti -p 5432:5432 postgres:15
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```