### PR TITLE
feat: add link to DAO docs in footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -52,6 +52,17 @@ export const Footer = (props: IFooterProps) => {
               </a>
             </span>
           ) : null}
+          <span className="hidden md:inline">&nbsp; | &nbsp;</span>
+          <span className="text-center block leading-6 md:inline md:text-left">
+            <a
+              className="xs:py-4 sm:py-0 xs:text-xl sm:text-sm"
+              target="_blank"
+              rel="noreferrer noopener"
+              href="https://dao-docs.api3.org/"
+            >
+              DAO Docs
+            </a>
+          </span>
           {blockNumber ? (
             <span className="hidden md:inline">&nbsp; | &nbsp;</span>
           ) : null}


### PR DESCRIPTION
Closes #123. Screenshot below, also looks fine on mobile.

![image](https://github.com/user-attachments/assets/45b3a058-649c-4fe2-b240-6efa0632fa97)
